### PR TITLE
Don't reconnect on error

### DIFF
--- a/cosmoz-sse.js
+++ b/cosmoz-sse.js
@@ -49,13 +49,6 @@ class CosmozSSE extends PolymerElement {
 				value: 'json'
 			},
 			/**
-			 * Whether to require to reconnect manually
-			 */
-			manualReconnect: {
-				type: Boolean,
-				value: false
-			},
-			/**
 			 * Whether CORS should include credentials.
 			 */
 			withCredentials: {
@@ -230,9 +223,6 @@ class CosmozSSE extends PolymerElement {
 	 * @return {void}
 	 */
 	_onError() {
-		if (this._source && !this.manualReconnect && this._source.readyState === EventSource.CLOSED) {
-			this.reconnect();
-		}
 		this.dispatchEvent(new CustomEvent('error'));
 	}
 }


### PR DESCRIPTION
This reconnect was added due to the fact that BE didn't properly establish the SSE-connections and they timed out, with an error code.
Browsers generally reconnect on their own unless the connection is closed by an error.
If closed by an error, we probably should catch that event in FE and log the user out or at least orchestrate the reconnection from outside this component.